### PR TITLE
Added Typewriter effect to Heading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
+        "react-simple-typewriter": "^4.0.5",
         "web-vitals": "^2.1.4"
       }
     },
@@ -16986,6 +16987,18 @@
         }
       }
     },
+    "node_modules/react-simple-typewriter": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/react-simple-typewriter/-/react-simple-typewriter-4.0.5.tgz",
+      "integrity": "sha512-2CmVpD1kTifRE8gixr2z+1aYS136ZbAC/UATNzvkzl4tSiThT/ATXH4rOGVwWLTlOWCVnSewObXo/kJlV2HMxw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -31536,6 +31549,12 @@
         "webpack-manifest-plugin": "^4.0.2",
         "workbox-webpack-plugin": "^6.4.1"
       }
+    },
+    "react-simple-typewriter": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/react-simple-typewriter/-/react-simple-typewriter-4.0.5.tgz",
+      "integrity": "sha512-2CmVpD1kTifRE8gixr2z+1aYS136ZbAC/UATNzvkzl4tSiThT/ATXH4rOGVwWLTlOWCVnSewObXo/kJlV2HMxw==",
+      "requires": {}
     },
     "react-transition-group": {
       "version": "4.4.5",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
+    "react-simple-typewriter": "^4.0.5",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import NewTransactions from './components/NewTransactions'
 import Transactions from './components/Transactions'
 import { useState } from 'react'
 import { Typography, styled, Box } from '@mui/material'
+import { Typewriter } from 'react-simple-typewriter'
 
 const Header = styled(Typography)`
   margin: 10px 0;
@@ -36,7 +37,9 @@ function App() {
 
   return (
     <Box className="App">
-      <Header>Expense Tracker</Header>
+      <Header>
+        <Typewriter words={["Expense Tracker"]} typeSpeed={120} />
+      </Header>
 
       <Component>
         <Box>


### PR DESCRIPTION
Fixes #8 

Referred to some CSS-only styles to add the typewriter effect, as I didn't have an exact idea to implement the same. All of them seemed to be either flaky, or not working at all (at least in this scenario), or they needed other changes which (_sort off_) messed the overall layout.

Hence went for this library `react-simple-typewriter`, smallest one that I found which serves the purpose. It also has some customizability if needed in future.